### PR TITLE
Change aws credential config key name

### DIFF
--- a/fluent.conf.sample
+++ b/fluent.conf.sample
@@ -18,10 +18,11 @@
   # AWS region.
   region "us-east-1"
 
-  # <aws_credentials>
-  #   access_key_id "XXXXXXXXX"
-  #   secret_access_key "XXXXXXXXXX"
-  # </aws_credentials>
+  # AWS access key id.
+  aws_key_id "XXXXXXXX"
+
+  # AWS secret key.
+  aws_sec_key "XXXXXXXX"
 
   # Specify which key should be 'measure'.
   # If not, plugin sends dummy measure and writes all keys and values as dimensions.

--- a/lib/fluent/plugin/out_timestream.rb
+++ b/lib/fluent/plugin/out_timestream.rb
@@ -12,11 +12,8 @@ module Fluent
 
       config_param :region, :string
 
-      config_section :aws_credentials,
-                     param_name: 'aws_credentials', required: false, multi: false do
-        config_param :access_key_id, :string, secret: true
-        config_param :secret_access_key, :string, secret: true
-      end
+      config_param :aws_key_id, :string, secret: true, default: nil
+      config_param :aws_sec_key, :string, secret: true, default: nil
 
       config_param :database, :string
       config_param :table, :string
@@ -39,10 +36,10 @@ module Fluent
       end
 
       def credential_options
-        if @aws_credentials
+        if @aws_key_id && @aws_sec_key
           {
-            access_key_id: @aws_credentials[:access_key_id],
-            secret_access_key: @aws_credentials[:secret_access_key]
+            access_key_id: @aws_key_id,
+            secret_access_key: @aws_sec_key
           }
         else
           {}


### PR DESCRIPTION
Motivation:

Credential config key name is different from other common fluent plugins.

Modifications:

delete "aws_credentials" section
access_key_id => aws_key_id
secret_access_key =>  aws_sec_key