### PR TITLE
Change "region" non-mandatory

### DIFF
--- a/fluent.conf.sample
+++ b/fluent.conf.sample
@@ -15,14 +15,12 @@
   # Amazon Timestream table name.
   table "sampleTable"
 
-  # AWS region. If not specified, search it from environment variable or aws config file.
+  # AWS access key id, secret key, region.
+  # If not specified, search it from environment variable or aws config file.
   # For more details see https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/TimestreamWrite/Client.html
-  # region "us-east-1"
-
-  # <aws_credentials>
-  #   access_key_id "XXXXXXXXX"
-  #   secret_access_key "XXXXXXXXXX"
-  # </aws_credentials>
+  aws_key_id "XXXXXXXX"
+  aws_sec_key "XXXXXXXX"
+  region "us-east-1"
 
   # Specify which key should be 'measure'.
   # If not, plugin sends dummy measure and writes all keys and values as dimensions.

--- a/fluent.conf.sample
+++ b/fluent.conf.sample
@@ -37,7 +37,7 @@
 
   # 'chunk_limit_records' must be configured less or equal to 100.
   # If not, plugin may fails to write record.
-  # For now, Plugin sends records in buffer all at once.
+  # For now, plugin sends records in buffer all at once.
   # However Amazon Timestream currently accepts less or equal to 100 records.
   <buffer>
     chunk_limit_records 100

--- a/fluent.conf.sample
+++ b/fluent.conf.sample
@@ -15,8 +15,9 @@
   # Amazon Timestream table name.
   table "sampleTable"
 
-  # AWS region.
-  region "us-east-1"
+  # AWS region. If not specified, search it from environment variable or aws config file.
+  # For more details see https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/TimestreamWrite/Client.html
+  # region "us-east-1"
 
   # <aws_credentials>
   #   access_key_id "XXXXXXXXX"

--- a/lib/fluent/plugin/out_timestream.rb
+++ b/lib/fluent/plugin/out_timestream.rb
@@ -10,7 +10,7 @@ module Fluent
     class TimestreamOutput < Fluent::Plugin::Output
       Fluent::Plugin.register_output('timestream', self)
 
-      config_param :region, :string
+      config_param :region, :string, default: nil
 
       config_section :aws_credentials,
                      param_name: 'aws_credentials', required: false, multi: false do
@@ -32,7 +32,7 @@ module Fluent
       def configure(conf)
         super
         options = credential_options
-        options[:region] = @region
+        options[:region] = @region if @region
         options[:endpoint] = @endpoint if @endpoint
         options[:ssl_verify_peer] = @ssl_verify_peer
         @client = Aws::TimestreamWrite::Client.new(options)


### PR DESCRIPTION
Motivation:

Currently, "region" is mandatory but sdk can search region from environment variable or aws config files.

Modifications:

Change "region" non-mandatory.