### PR TITLE
Convert non-string value to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ You can install it as follows:
 
 ## Configuration
 Please refer to the [sample config file](https://github.com/StudistCorporation/fluent-plugin-timestream/blob/main/fluent.conf.sample)
+
+## Note
+If log file contains null value, plugin convert it to empty string.

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ You can install it as follows:
 Please refer to the [sample config file](https://github.com/StudistCorporation/fluent-plugin-timestream/blob/main/fluent.conf.sample)
 
 ## Note
-If log file contains null value, plugin convert it to empty string.
+The plugin converts `nil` values in the log to empty string.

--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ You can install it as follows:
 Please refer to the [sample config file](https://github.com/StudistCorporation/fluent-plugin-timestream/blob/main/fluent.conf.sample)
 
 ## Note
-The plugin converts `nil` values in the log to empty string.
+The plugin converts `null` values in the log to empty string.  
+e.g. `{key_name: null}` => `{key_name: ""}`

--- a/lib/fluent/plugin/out_timestream.rb
+++ b/lib/fluent/plugin/out_timestream.rb
@@ -64,7 +64,7 @@ module Fluent
           time: time.to_s,
           time_unit: 'SECONDS',
           measure_name: measure[:name],
-          measure_value: measure[:value],
+          measure_value: measure[:value].to_s,
           measure_value_type: measure[:type]
         }
       end
@@ -73,7 +73,7 @@ module Fluent
         {
           dimension_value_type: 'VARCHAR',
           name: key,
-          value: value
+          value: value.to_s
         }
       end
 


### PR DESCRIPTION
Motivation:

When log file contain non string value (e.g. INTEGER, nil), plugin fails to write records, because sdk accept only string value.

Modifications:

When create dimension and measure, convert value to string.