### PR TITLE
Use ENV if "database" or "table" is not specified.

### DIFF
--- a/fluent.conf.sample
+++ b/fluent.conf.sample
@@ -10,11 +10,11 @@
   @type timestream
 
   # Amazon Timestream database name.
-  # If not specified, plugin use ENV['AWS_TIMESTREAM_DATABASE']
+  # If not specified, the AWS_TIMESTREAM_DATABASE environment variable will be used instead
   database "sampleDB"
 
   # Amazon Timestream table name.
-  # If not specified, plugin use ENV['AWS_TIMESTREAM_TABLE']
+  # If not specified, the AWS_TIMESTREAM_TABLE environment variable will be used instead
   table "sampleTable"
 
   # AWS region.

--- a/fluent.conf.sample
+++ b/fluent.conf.sample
@@ -10,9 +10,11 @@
   @type timestream
 
   # Amazon Timestream database name.
+  # If not specified, plugin use ENV['AWS_TIMESTREAM_DATABASE']
   database "sampleDB"
 
   # Amazon Timestream table name.
+  # If not specified, plugin use ENV['AWS_TIMESTREAM_TABLE']
   table "sampleTable"
 
   # AWS region.

--- a/lib/fluent/plugin/out_timestream.rb
+++ b/lib/fluent/plugin/out_timestream.rb
@@ -34,8 +34,8 @@ module Fluent
         options[:ssl_verify_peer] = @ssl_verify_peer
         @client = Aws::TimestreamWrite::Client.new(options)
 
-        @database = ENV['AWS_TIMESTREAM_DATABASE']
-        @table = ENV['AWS_TIMESTREAM_TABLE']
+        @database = ENV['AWS_TIMESTREAM_DATABASE'] if @database.nil?
+        @table = ENV['AWS_TIMESTREAM_TABLE'] if @table.nil?
       end
 
       def credential_options

--- a/lib/fluent/plugin/out_timestream.rb
+++ b/lib/fluent/plugin/out_timestream.rb
@@ -15,8 +15,8 @@ module Fluent
       config_param :aws_key_id, :string, secret: true, default: nil
       config_param :aws_sec_key, :string, secret: true, default: nil
 
-      config_param :database, :string
-      config_param :table, :string
+      config_param :database, :string, default: nil
+      config_param :table, :string, default: nil
       config_section :measure,
                      param_name: 'target_measure', required: false, multi: false do
         config_param :name, :string
@@ -33,6 +33,9 @@ module Fluent
         options[:endpoint] = @endpoint if @endpoint
         options[:ssl_verify_peer] = @ssl_verify_peer
         @client = Aws::TimestreamWrite::Client.new(options)
+
+        @database = ENV['AWS_TIMESTREAM_DATABASE']
+        @table = ENV['AWS_TIMESTREAM_TABLE']
       end
 
       def credential_options

--- a/test/test_out_timestream.rb
+++ b/test/test_out_timestream.rb
@@ -15,6 +15,16 @@ class TimestreamOutputTest < Test::Unit::TestCase
     @server.start
   end
 
+  test 'get database name and table name from ENV' do
+    ENV['AWS_TIMESTREAM_DATABASE'] = 'TEST_DB'
+    ENV['AWS_TIMESTREAM_TABLE'] = 'TEST_TABLE'
+    d = create_driver('region "test"')
+    assert_equal 'TEST_DB', d.instance.database
+    assert_equal 'TEST_TABLE', d.instance.table
+    ENV.delete('AWS_TIMESTREAM_DATABASE')
+    ENV.delete('AWS_TIMESTREAM_TABLE')
+  end
+
   test 'single record' do
     d = create_driver
     time = event_time('2021-01-01 11:11:11 UTC')
@@ -164,7 +174,7 @@ class TimestreamOutputTest < Test::Unit::TestCase
         table dummyTable
         endpoint https://localhost:#{@server.port}
         ssl_verify_peer false
-        chunk_limit records 2
+        chunk_limit records 1
       )
     end
 

--- a/test/test_out_timestream.rb
+++ b/test/test_out_timestream.rb
@@ -174,7 +174,7 @@ class TimestreamOutputTest < Test::Unit::TestCase
         table dummyTable
         endpoint https://localhost:#{@server.port}
         ssl_verify_peer false
-        chunk_limit records 1
+        chunk_limit records 2
       )
     end
 


### PR DESCRIPTION
Motivation:

Currently, "database" and "table" are mandatory but it is more convenient if plugin use ENV when they are not specified.

Modifications:

Use ENV when "database" or "table" is not specified
ENV['AWS_TIMESTREAM_DATABASE']
ENV['AWS_TIMESTREAM_TABLE']