### PR TITLE
Fix README, log message. Delete redandunt config item in test

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ e.g. `{key_name: null}` => `{key_name: ""}`
   
 When writing Timestream records, `TimeUnit` is always set to `SECONDS`  
   
-Configure multiple MeasureName is not supported.
+Configuring multiple `MeasureName`s is not supported.

--- a/README.md
+++ b/README.md
@@ -12,4 +12,8 @@ Please refer to the [sample config file](https://github.com/StudistCorporation/f
 
 ## Note
 The plugin converts `null` values in the log to empty string.  
-e.g. `{key_name: null}` => `{key_name: ""}`
+e.g. `{key_name: null}` => `{key_name: ""}`  
+  
+When write Timestream records, TimeUnit is always set `SECONDS`  
+  
+Configure multiple MeasureName is not supported.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Please refer to the [sample config file](https://github.com/StudistCorporation/f
 The plugin converts `null` values in the log to empty string.  
 e.g. `{key_name: null}` => `{key_name: ""}`  
   
-When write Timestream records, TimeUnit is always set `SECONDS`  
+When writing Timestream records, `TimeUnit` is always set to `SECONDS`  
   
 Configure multiple MeasureName is not supported.

--- a/lib/fluent/plugin/out_timestream.rb
+++ b/lib/fluent/plugin/out_timestream.rb
@@ -97,7 +97,7 @@ module Fluent
           timestream_records.push(create_timestream_record(dimensions, time, measure))
         end
 
-        log.info("write #{timestream_records.length} records")
+        log.info("read #{timestream_records.length} records from chunk")
         timestream_records
       end
 

--- a/test/test_out_timestream.rb
+++ b/test/test_out_timestream.rb
@@ -174,7 +174,6 @@ class TimestreamOutputTest < Test::Unit::TestCase
         table dummyTable
         endpoint https://localhost:#{@server.port}
         ssl_verify_peer false
-        chunk_limit records 2
       )
     end
 


### PR DESCRIPTION
Motivation:

README should have some restriction about TimeUnit and MeasureName.
Log message output when create Timestream records inappropriate.
Default config in test has redundant config item.

Modifications:

Add restriction to README.
Fix log message.
Delete redundant config item.