### PR TITLE
Ignore record or dimension when they have an empty value

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ You can install it as follows:
 Please refer to the [sample config file](https://github.com/StudistCorporation/fluent-plugin-timestream/blob/main/fluent.conf.sample)
 
 ## Note
-The plugin converts `null` values in the log to empty string.  
-e.g. `{key_name: null}` => `{key_name: ""}`  
+The plugin ignores `null` and empty string values in the log.  
+e.g. `{key1: null, key2: "value", key3: ""}` => `{key2: "value"}`  
   
 When writing Timestream records, `TimeUnit` is always set to `SECONDS`  
   

--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@ You can install it as follows:
 Please refer to the [sample config file](https://github.com/StudistCorporation/fluent-plugin-timestream/blob/main/fluent.conf.sample)
 
 ## Note
-The plugin ignores `null` and empty string values in the log.  
-e.g. `{key1: null, key2: "value", key3: ""}` => `{key2: "value"}`  
+The plugin ignores dimension when it has `null` or empty string value.  
+e.g. `{dimension1: null, dimension2: "value", dimension3: ""}` => `{dimension2: "value"}`  
+  
+The Plugin ignores record when it has no dimensions.
+e.g. `{dimension1: null, dimension2: "", measure: "value"}` => ignores this record  
+  
+The Plugin ignores record when measure specified in the config has `null` or empty value.  
+e.g. `{dimension1: "value", measure: ""}` => ignores this record
   
 When writing Timestream records, `TimeUnit` is always set to `SECONDS`  
   

--- a/lib/fluent/plugin/out_timestream.rb
+++ b/lib/fluent/plugin/out_timestream.rb
@@ -70,22 +70,25 @@ module Fluent
       end
 
       def create_timestream_dimension(key, value)
+        value = value.to_s
+        return nil if value.empty?
+
         {
           dimension_value_type: 'VARCHAR',
           name: key,
-          value: value.to_s
+          value: value
         }
       end
 
       def create_timestream_dimensions_and_measure(record)
-        dimensions = []
         measure = {}
-        record.each do |k, v|
+        dimensions = record.each_with_object([]) do |(k, v), result|
           if @target_measure && k == @target_measure[:name]
             measure = { name: k, value: v, type: @target_measure[:type] }
             next
           end
-          dimensions.push(create_timestream_dimension(k, v))
+          dimension = create_timestream_dimension(k, v)
+          result.push(dimension) unless dimension.nil?
         end
         return [dimensions, measure]
       end

--- a/lib/fluent/plugin/out_timestream.rb
+++ b/lib/fluent/plugin/out_timestream.rb
@@ -133,8 +133,8 @@ module Fluent
           dimensions, measure = create_timestream_dimensions_and_measure(record)
           timestream_records.push(create_timestream_record(dimensions, time, measure))
         rescue EmptyValueError, NoDimensionsError => e
-          log.warn("ignore record (#{e})")
-          log.warn("ignored record details: #{record}")
+          log.warn("ignored record due to (#{e})")
+          log.debug("ignored record details: #{record}")
           next
         end
 

--- a/test/test_out_timestream.rb
+++ b/test/test_out_timestream.rb
@@ -151,17 +151,54 @@ class TimestreamOutputTest < Test::Unit::TestCase
     measure_name = 'measure'
     measure_value_type = 'VARCHAR'
     measure_value = nil
-    test_with_measure(measure_name, measure_value_type, measure_value)
+    test_with_measure_empty_value(measure_name, measure_value_type, measure_value)
+  end
+
+  test 'with measure(VARCHAR - empty)' do
+    measure_name = 'measure'
+    measure_value_type = 'VARCHAR'
+    measure_value = ''
+    test_with_measure_empty_value(measure_name, measure_value_type, measure_value)
   end
 
   test 'with measure(INTEGER - nil)' do
     measure_name = 'measure'
     measure_value_type = 'INTEGER'
     measure_value = nil
-    test_with_measure(measure_name, measure_value_type, measure_value)
+    test_with_measure_empty_value(measure_name, measure_value_type, measure_value)
   end
 
   private
+
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
+    def test_with_measure_empty_value(measure_name, measure_value_type, measure_value)
+      d = create_driver(default_config +
+        "<measure>
+          name #{measure_name}
+          type #{measure_value_type}
+        </measure>")
+
+      time1 = event_time('2021-01-01 11:11:11 UTC')
+      time2 = event_time('2021-01-02 11:11:11 UTC')
+      log1 = create_log(key_base: KEY, value_base: VALUE, dimension_num: 2)
+      log1[measure_name] = measure_value
+      log2 = create_log(key_base: KEY, value_base: VALUE, dimension_num: 2)
+
+      d.run(default_tag: 'test') do
+        # log1 will be ignored because it has empty measure value
+        d.feed(time1, log1)
+        d.feed(time2, log2)
+      end
+
+      records = @server.request_records
+      assert_equal 1, records.length
+
+      dimensions = create_expected_dimensions(log2)
+      verify_requested_record(records[0], time2, dimensions)
+    end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize

--- a/test/test_out_timestream.rb
+++ b/test/test_out_timestream.rb
@@ -133,6 +133,26 @@ class TimestreamOutputTest < Test::Unit::TestCase
     verify_requested_record(records[2], time3, dimensions)
   end
 
+  test 'multiple records(ignore no dimensions record)' do
+    d = create_driver
+    time1 = event_time('2021-01-01 01:00:00 UTC')
+    time2 = event_time('2021-01-03 03:00:00 UTC')
+
+    log1 = { 'key1' => '' }
+    log2 = { 'key1' => 'value' }
+
+    d.run(default_tag: 'test') do
+      d.feed(time1, log1)
+      d.feed(time2, log2)
+    end
+
+    records = @server.request_records
+    assert_equal 1, records.length
+
+    dimensions = create_expected_dimensions(log2)
+    verify_requested_record(records[0], time2, dimensions)
+  end
+
   test 'with measure(STRING)' do
     measure_name = 'measure'
     measure_value_type = 'VARCHAR'

--- a/test/test_out_timestream.rb
+++ b/test/test_out_timestream.rb
@@ -56,7 +56,7 @@ class TimestreamOutputTest < Test::Unit::TestCase
   test 'single record(empty string)' do
     d = create_driver
     time = event_time('2021-01-01 01:00:00 UTC')
-    log = { 'key' => '' }
+    log = { 'key1' => '', 'key2' => 'val' }
 
     d.run(default_tag: 'test') do
       d.feed(time, log)
@@ -65,7 +65,7 @@ class TimestreamOutputTest < Test::Unit::TestCase
     records = @server.request_records
     assert_equal 1, records.length
 
-    dimensions = create_expected_dimensions(log)
+    dimensions = create_expected_dimensions({ 'key2' => 'val' })
 
     verify_requested_record(records[0], time, dimensions)
   end
@@ -73,7 +73,7 @@ class TimestreamOutputTest < Test::Unit::TestCase
   test 'single record(nil)' do
     d = create_driver
     time = event_time('2021-01-01 01:00:00 UTC')
-    log = { 'key' => nil }
+    log = { 'key1' => nil, 'key2' => 'val' }
 
     d.run(default_tag: 'test') do
       d.feed(time, log)
@@ -82,7 +82,7 @@ class TimestreamOutputTest < Test::Unit::TestCase
     records = @server.request_records
     assert_equal 1, records.length
 
-    dimensions = create_expected_dimensions(log)
+    dimensions = create_expected_dimensions({ 'key2' => 'val' })
 
     verify_requested_record(records[0], time, dimensions)
   end
@@ -209,7 +209,7 @@ class TimestreamOutputTest < Test::Unit::TestCase
       assert_equal measure_value, record['MeasureValue']
       assert_equal measure_value_type, record['MeasureValueType']
 
-      assert_equal record['Dimensions'], dimensions
+      assert_equal dimensions, record['Dimensions']
     end
     # rubocop: enable Metrics/ParameterLists
 


### PR DESCRIPTION
Motivation:

Timestream now reject record which has empty value in dimensions or measure.
When call WriteRecords API and even one record has an empty value in dimensions or measure, **fails to write all records (include valid records).**
Plugin should ignore such dimensions or records so that succeed to write valid records.

Modifications:

When dimension has an empty value, ignore the dimension. If record has other non-empty dimension, plugin write the record.
When measure has an empty value, ignore the record.
When record has no dimensions, ignore the record.