### PR TITLE
support XXX seconds

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   TargetRubyVersion: 2.6
+  SuggestExtensions: false
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please refer to the [sample config file](https://github.com/StudistCorporation/f
 The plugin ignores dimension when it has `null` or empty string value.  
 e.g. `{dimension1: null, dimension2: "value", dimension3: ""}` => `{dimension2: "value"}`
 
-The plugin ignores record when it has no dimensions.
+The plugin ignores record when it has no dimensions.  
 e.g. `{dimension1: null, dimension2: "", measure: "value"}` => ignores this record
 
 The plugin ignores record when measure specified in the config has `null` or empty value.  

--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # fluent-plugin-timestream
+
 [![Status](https://circleci.com/gh/StudistCorporation/fluent-plugin-timestream.svg?style=shield)](https://circleci.com/gh/StudistCorporation/fluent-plugin-timestream)
 
 Fluentd output plugin for Amazon Timestream.
 
-
 ## Installation
+
 You can install it as follows:
 
     $ fluent-gem install fluent-plugin-timestream
 
 ## Configuration
+
 Please refer to the [sample config file](https://github.com/StudistCorporation/fluent-plugin-timestream/blob/main/fluent.conf.sample)
 
 ## Note
+
 The plugin ignores dimension when it has `null` or empty string value.  
-e.g. `{dimension1: null, dimension2: "value", dimension3: ""}` => `{dimension2: "value"}`  
-  
-The Plugin ignores record when it has no dimensions.
-e.g. `{dimension1: null, dimension2: "", measure: "value"}` => ignores this record  
-  
-The Plugin ignores record when measure specified in the config has `null` or empty value.  
+e.g. `{dimension1: null, dimension2: "value", dimension3: ""}` => `{dimension2: "value"}`
+
+The plugin ignores record when it has no dimensions.
+e.g. `{dimension1: null, dimension2: "", measure: "value"}` => ignores this record
+
+The plugin ignores record when measure specified in the config has `null` or empty value.  
 e.g. `{dimension1: "value", measure: ""}` => ignores this record
-  
-When writing Timestream records, `TimeUnit` is always set to `SECONDS`  
-  
+
 Configuring multiple `MeasureName`s is not supported.

--- a/fluent.conf.sample
+++ b/fluent.conf.sample
@@ -1,10 +1,31 @@
 <source>
   @type tail
-  format ltsv
+  format json
   path /path/to/sample.log
   pos_file /tmp/sample.pos
   tag "sample.log"
+  # set keep_time_key true if need to convert time.
+  # keep_time_key true
 </source>
+
+# If more than seconds accuracy is needed,
+# convert time and configure time_unit and time_key.
+#
+# e.g.)
+# If record is as follows:
+# {"key": "value", "time":1620000000.123456789}
+#
+# convert it to: 
+# when time unit is MILLISECONDS: 1620000000123
+# when time unit is MICROSECONDS: 1620000000123456
+# when time unit is NANOSECONDS:  1620000000123456789
+# <filter sample.log>
+  # @type record_transformer
+  # enable_ruby true
+  # <record>
+  #   milliseconds_time ${(record["time"].to_f * 1000).to_i}
+  # </record>
+#</filter>
 
 <match sample.log>
   @type timestream
@@ -23,6 +44,17 @@
   aws_key_id "XXXXXXXX"
   aws_sec_key "XXXXXXXX"
   region "us-east-1"
+
+  # If more than seconds accuracy is needed,
+  # convert time and configure time_unit and time_key.
+  # time_unit: The granularity of the timestamp unit. 
+  #            This value is used for 'TimeUnit' in Timestream record
+  #            Default value: SECONDS
+  #            Valid values: SECONDS MILLISECONDS MICROSECONDS NANOSECONDS
+  # time_key:  Specify record key which contains integer epoch time corresponding to time_unit
+  #            Plugin uses specified epoch time for 'Time' in Timestream record and does not send it as dimension
+  # time_unit "MILLISECONDS"
+  # time_key "milliseconds_time"
 
   # Specify which key should be 'measure'.
   # If not, plugin sends dummy measure and writes all keys and values as dimensions.


### PR DESCRIPTION
Motivation:
Enable to write record which has more than seconds accuracy.
Amazon Timstream supports MILLISECONDS, MICROSECONDS, NANOSECONDS

Modifications:
Add 2 config item (time_unit, time_key)
Fix test and documents