### PR TITLE
Fix lack of configuration in the fluent config sample

### DIFF
--- a/fluent.conf.sample
+++ b/fluent.conf.sample
@@ -25,7 +25,8 @@
   # <record>
   #   milliseconds_time ${(record["time"].to_f * 1000).to_i}
   # </record>
-  # Remove time key or plugin sends it as a dimension and fails to write.
+  # Remove time key or plugin sends it as a dimension.
+  # Especially, if time key name is 'time', the plugin fails to write record because 'time' is reserved keyword.
   # remove_keys time
 #</filter>
 

--- a/fluent.conf.sample
+++ b/fluent.conf.sample
@@ -25,6 +25,8 @@
   # <record>
   #   milliseconds_time ${(record["time"].to_f * 1000).to_i}
   # </record>
+  # Remove time key or plugin sends it as a dimension and fails to write.
+  # remove_keys time
 #</filter>
 
 <match sample.log>


### PR DESCRIPTION
Motivation:
If fluent.conf.sample is applied, the plugin may fails to write record.

Modifications:
Add sample configuration