### PR TITLE
Enable retry on error

### DIFF
--- a/lib/fluent/plugin/out_timestream.rb
+++ b/lib/fluent/plugin/out_timestream.rb
@@ -175,8 +175,6 @@ module Fluent
         )
       rescue Aws::TimestreamWrite::Errors::RejectedRecordsException => e
         log.error(e.rejected_records)
-      rescue StandardError => e
-        log.error(e.message)
       end
 
     end

--- a/test/server.rb
+++ b/test/server.rb
@@ -20,7 +20,6 @@ class TestServer
     @server.mount_proc '/' do |req, res|
       @request_body = req.body
       res.status = 200
-      res.body = 'RESPONSE'
     end
 
     @request_body = ''


### PR DESCRIPTION
Motivation:
Enable retry on failure to write Timestream record.

Modifications:
Delete rescue for StandardError.